### PR TITLE
Fix mobile dialogues height shift

### DIFF
--- a/client/app/account/dialogues/[id]/page.tsx
+++ b/client/app/account/dialogues/[id]/page.tsx
@@ -209,7 +209,7 @@ export default function AccountDialogues({
 							flex: !currentChat,
 						}
 					)}
-					style={{ height: (window.innerHeight / 100) * 65 }}
+                                        style={{ height: "calc(var(--vh, 1vh) * 65)" }}
 				>
 					{sortedChats?.map((chat: any) => (
 						<button
@@ -285,7 +285,7 @@ export default function AccountDialogues({
 									"hidden md:flex": !currentChat,
 								}
 							)}
-							style={{ height: ((window.innerHeight - 210) / 100) * 70 }}
+                                                        style={{ height: "calc((var(--vh, 1vh) * 100 - 210px) * 0.7)" }}
 						>
 							<div className="flex flex-col gap-4 w-full">
 								{chat ? (

--- a/client/app/providers.tsx
+++ b/client/app/providers.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider as NextThemesProvider } from "next-themes";
 
 import { Providers as ReduxProvider } from "@/redux/provider";
 import { SocketListener } from "@/components/SocketListener";
+import { useViewportHeight } from "@/hooks/useViewportHeight";
 
 export interface ProvidersProps {
   children: React.ReactNode;
@@ -25,6 +26,9 @@ declare module "@react-types/shared" {
 
 export function Providers({ children, themeProps }: ProvidersProps) {
   const router = useRouter();
+
+  // Update CSS variable for viewport height to improve mobile layout behavior
+  useViewportHeight();
 
   return (
     <ReduxProvider>

--- a/client/hooks/useViewportHeight.ts
+++ b/client/hooks/useViewportHeight.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Hook to set --vh CSS variable based on the current viewport height
+export const useViewportHeight = () => {
+  useEffect(() => {
+    const setVh = () => {
+      if (typeof window !== "undefined") {
+        const vh = window.innerHeight * 0.01;
+        document.documentElement.style.setProperty("--vh", `${vh}px`);
+      }
+    };
+
+    setVh();
+    window.addEventListener("resize", setVh);
+
+    return () => {
+      window.removeEventListener("resize", setVh);
+    };
+  }, []);
+};

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --vh: 1vh;
+}
+
 * {
   outline: none !important;
 }


### PR DESCRIPTION
## Summary
- add hook to maintain `--vh` viewport unit
- initialize viewport variable in `Providers`
- use dynamic `--vh` unit in dialogues page to avoid iOS jumping
- set default `--vh` in global styles

## Testing
- `npm run lint` (fails: Module needs an import attribute)
- `npm run lint` in server (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68629d3de66c83338ad4f924529cfa47